### PR TITLE
Bump to Ruby 1.9.3

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,1 @@
-rvm use 1.9.2@angular_rails_demo
+rvm use 1.9.3@angular_rails_demo --create

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ end
 
 group :development, :test do
   gem 'rspec-rails'
-  gem 'ruby-debug19', :require => 'ruby-debug'
   gem 'jasmine'
   gem 'jasminerice'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,7 +30,6 @@ GEM
     activesupport (3.1.1)
       multi_json (~> 1.0)
     addressable (2.2.6)
-    archive-tar-minitar (0.5.2)
     arel (2.2.1)
     builder (3.0.0)
     capybara (1.0.0)
@@ -49,7 +48,6 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.1.3)
-    columnize (0.3.4)
     database_cleaner (0.7.0)
     diff-lcs (1.1.3)
     erubis (2.7.0)
@@ -74,8 +72,6 @@ GEM
     json_pure (1.6.1)
     launchy (2.0.5)
       addressable (~> 2.2.6)
-    linecache19 (0.5.12)
-      ruby_core_source (>= 0.1.4)
     mail (2.3.0)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
@@ -128,16 +124,6 @@ GEM
       activesupport (~> 3.0)
       railties (~> 3.0)
       rspec (~> 2.7.0)
-    ruby-debug-base19 (0.11.25)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby_core_source (>= 0.1.4)
-    ruby-debug19 (0.11.6)
-      columnize (>= 0.3.1)
-      linecache19 (>= 0.5.11)
-      ruby-debug-base19 (>= 0.11.19)
-    ruby_core_source (0.1.5)
-      archive-tar-minitar (>= 0.5.2)
     rubyzip (0.9.4)
     sass (3.1.10)
     sass-rails (3.1.4)
@@ -184,7 +170,6 @@ DEPENDENCIES
   rails
   rmagick
   rspec-rails
-  ruby-debug19
   sass-rails (~> 3.1.0)
   spork (~> 0.9.0.rc2)
   sqlite3


### PR DESCRIPTION
Just didn't even have 1.9.2 installed on my machine and figured it's best to be on the latest stable. I also removed ruby-debug because it doesn't work with 1.9.3 and doesn't seem essential.
